### PR TITLE
Add: actuator, quartz, jpa auditing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ WORKDIR /app
 ARG APP_USER=appuser
 ARG APP_USER_GROUP=appgroup
 
-COPY --from=builder /build/target/*.jar app.jar
+RUN groupadd -r ${APP_USER_GROUP} && useradd -r -g ${APP_USER_GROUP} ${APP_USER}
 
-COPY --from=builder /build/src/main/resources /build/src/main/
+COPY --from=builder /build/target/*.jar app.jar
 
 RUN chown -R ${APP_USER}:${APP_USER_GROUP} /app
 
@@ -29,4 +29,4 @@ USER ${APP_USER}
 
 EXPOSE 8080
 
-ENTRYPOINT [ "sh", "-c", "java -jar app.jar"]
+ENTRYPOINT [ "sh", "-c", "java -jar app.jar" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - DATABASE_PASSWORD=postgres
     depends_on:
       - java_db
-
+      
   java_db:
     container_name: java_db
     image: postgres:12

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+		<!-- <dependency>
+			<groupId>org.quartz-scheduler</groupId>
+			<artifactId>quartz</artifactId>
+			<version>2.5.0</version>
+		</dependency> -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-quartz</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/kubuski/urlshortener/UrlshortenerApplication.java
+++ b/src/main/java/com/kubuski/urlshortener/UrlshortenerApplication.java
@@ -2,7 +2,9 @@ package com.kubuski.urlshortener;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class UrlshortenerApplication {
 

--- a/src/main/java/com/kubuski/urlshortener/config/QuartzConfig.java
+++ b/src/main/java/com/kubuski/urlshortener/config/QuartzConfig.java
@@ -1,0 +1,35 @@
+package com.kubuski.urlshortener.config;
+
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+import com.kubuski.urlshortener.job.UrlCleanupJob;
+
+@Configuration
+public class QuartzConfig {
+    @Bean
+    public JobDetail urlCleanupJobDetail() {
+        return JobBuilder.newJob(UrlCleanupJob.class).withIdentity("urlCleanupJob").storeDurably().build();
+    }
+
+    @Bean
+    public Trigger urlCleanupJobTrigger() {
+        return TriggerBuilder.newTrigger().forJob(urlCleanupJobDetail()).withIdentity("urlCleanupTrigger")
+                .withSchedule(CronScheduleBuilder.cronSchedule("0 0 0 * * ?")).build();
+    }
+
+    @Bean
+    public SchedulerFactoryBean schedulerFactoryBean() {
+        SchedulerFactoryBean schedulerFactoryBean = new SchedulerFactoryBean();
+        schedulerFactoryBean.setJobDetails(urlCleanupJobDetail());
+        schedulerFactoryBean.setTriggers(urlCleanupJobTrigger());
+
+        return schedulerFactoryBean;
+    }
+}

--- a/src/main/java/com/kubuski/urlshortener/controller/UrlController.java
+++ b/src/main/java/com/kubuski/urlshortener/controller/UrlController.java
@@ -37,11 +37,12 @@ final class UrlController {
     @ResponseStatus(HttpStatus.OK)
     public UrlResponse getOriginalUrl(@PathVariable(name = "shortUrl") String shortUrl) {
         return urlService.getOriginalUrl(shortUrl);
-    } 
+    }
 
     @PutMapping("/{shortUrl}")
     @ResponseStatus(HttpStatus.OK)
-    public UrlResponse updateOriginalUrl(@PathVariable(name = "shortUrl") String shortUrl, @RequestBody UrlRequest urlRequest) {
+    public UrlResponse updateOriginalUrl(@PathVariable(name = "shortUrl") String shortUrl,
+            @RequestBody UrlRequest urlRequest) {
         return urlService.updateOriginalUrl(shortUrl, urlRequest);
     }
 

--- a/src/main/java/com/kubuski/urlshortener/dto/UrlRequest.java
+++ b/src/main/java/com/kubuski/urlshortener/dto/UrlRequest.java
@@ -2,4 +2,5 @@ package com.kubuski.urlshortener.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 
-public record UrlRequest(@NotEmpty String url) {}
+public record UrlRequest(@NotEmpty String url) {
+}

--- a/src/main/java/com/kubuski/urlshortener/dto/UrlResponse.java
+++ b/src/main/java/com/kubuski/urlshortener/dto/UrlResponse.java
@@ -3,11 +3,11 @@ package com.kubuski.urlshortener.dto;
 import java.time.Instant;
 
 public record UrlResponse(
-    Long id,
-    String originalUrl,
-    String shortUrl,
-    Instant createdAt,
-    Instant updatedAt,
-    Instant expirationDate,
-    int accessCount
-    ) {}
+        Long id,
+        String originalUrl,
+        String shortUrl,
+        Instant createdAt,
+        Instant updatedAt,
+        Instant expirationDate,
+        int accessCount) {
+}

--- a/src/main/java/com/kubuski/urlshortener/entity/Url.java
+++ b/src/main/java/com/kubuski/urlshortener/entity/Url.java
@@ -9,6 +9,9 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import java.time.Instant;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
 @Table(name = "urls")
 @Entity
 @Data
@@ -23,10 +26,12 @@ public class Url {
     @Column(unique = true, nullable = false, name = "short_url")
     private String shortUrl;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", updatable = false)
+    @CreatedDate
     private Instant createdAt;
 
     @Column(name = "updated_at")
+    @LastModifiedDate
     private Instant updatedAt;
 
     @Column(name = "expiration_date")
@@ -34,4 +39,7 @@ public class Url {
 
     @Column(name = "access_count")
     private int accessCount;
+
+    @Column(name = "deleted")
+    private boolean deleted;
 }

--- a/src/main/java/com/kubuski/urlshortener/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/kubuski/urlshortener/exceptions/ResourceNotFoundException.java
@@ -1,7 +1,0 @@
-package com.kubuski.urlshortener.exceptions;
-
-public class ResourceNotFoundException extends RuntimeException {
-    public ResourceNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/kubuski/urlshortener/job/UrlCleanupJob.java
+++ b/src/main/java/com/kubuski/urlshortener/job/UrlCleanupJob.java
@@ -1,0 +1,32 @@
+package com.kubuski.urlshortener.job;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+
+import com.kubuski.urlshortener.entity.Url;
+import com.kubuski.urlshortener.repository.UrlRepository;
+
+@Component
+public class UrlCleanupJob extends QuartzJobBean {
+    private final UrlRepository urlRepository;
+
+    @Value("${urlentity.lifetime.days}")
+    private int entityLifetimeDays;
+
+    public UrlCleanupJob(UrlRepository urlRepository) {
+        this.urlRepository = urlRepository;
+    }
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) {
+        Instant cutoffDate = Instant.now().minus(entityLifetimeDays, ChronoUnit.DAYS);
+        List<Url> urlsToDelete = urlRepository.findAllByDeletedTrueAndUpdatedAtBefore(cutoffDate);
+        urlRepository.deleteAll(urlsToDelete);
+    }
+}

--- a/src/main/java/com/kubuski/urlshortener/repository/UrlRepository.java
+++ b/src/main/java/com/kubuski/urlshortener/repository/UrlRepository.java
@@ -1,5 +1,7 @@
 package com.kubuski.urlshortener.repository;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,5 +9,7 @@ import com.kubuski.urlshortener.entity.Url;
 
 public interface UrlRepository extends JpaRepository<Url, Long> {
     Optional<Url> getUrlById(Long id);
-    Optional<Url> findByShortUrl(String shortUrl);
+    // Optional<Url> findByShortUrl(String shortUrl);
+    Optional<Url> findByShortUrlAndDeletedFalse(String shortUrl);
+    List<Url> findAllByDeletedTrueAndUpdatedAtBefore(Instant cutoffDate);
 }

--- a/src/main/java/com/kubuski/urlshortener/service/UrlService.java
+++ b/src/main/java/com/kubuski/urlshortener/service/UrlService.java
@@ -5,12 +5,10 @@ import org.springframework.stereotype.Service;
 import com.kubuski.urlshortener.dto.UrlRequest;
 import com.kubuski.urlshortener.dto.UrlResponse;
 import com.kubuski.urlshortener.entity.Url;
-import com.kubuski.urlshortener.exceptions.ResourceNotFoundException;
 import com.kubuski.urlshortener.repository.UrlRepository;
-import java.time.Instant;
 
 @Service
-public class UrlService{
+public class UrlService {
     private final UrlRepository urlRepository;
 
     public UrlService(UrlRepository urlRepository) {
@@ -19,74 +17,84 @@ public class UrlService{
 
     public UrlResponse createShortUrl(UrlRequest originalUrl) {
         Url url = new Url();
-        url.setOriginalUrl(originalUrl.toString());
+        url.setOriginalUrl(originalUrl.url());
         url.setShortUrl(generateShortCode());
-        url.setCreatedAt(Instant.now());
-        url.setUpdatedAt(Instant.now());
         url.setExpirationDate(null);
         url.setAccessCount(0);
+        url.setDeleted(false);
 
         Url savedUrl = urlRepository.save(url);
 
         return new UrlResponse(
-            savedUrl.getId(),
-            savedUrl.getOriginalUrl(),
-            savedUrl.getShortUrl(),
-            savedUrl.getCreatedAt(),
-            savedUrl.getUpdatedAt(),
-            savedUrl.getExpirationDate(),
-            savedUrl.getAccessCount()
-        );
+                savedUrl.getId(),
+                savedUrl.getOriginalUrl(),
+                savedUrl.getShortUrl(),
+                savedUrl.getCreatedAt(),
+                savedUrl.getUpdatedAt(),
+                savedUrl.getExpirationDate(),
+                savedUrl.getAccessCount());
     }
 
     public UrlResponse getOriginalUrl(String shortUrl) {
-        Url url = urlRepository.findByShortUrl(shortUrl).orElseThrow(() -> new ResourceNotFoundException("URL not found: " + shortUrl));
+        Url url = urlRepository.findByShortUrlAndDeletedFalse(shortUrl)
+                .orElseThrow(() -> new RuntimeException("URL not found: " + shortUrl));
 
         url.setAccessCount(url.getAccessCount() + 1);
 
         Url updatedUrl = urlRepository.save(url);
 
         return new UrlResponse(
-            updatedUrl.getId(),
-            updatedUrl.getOriginalUrl(),
-            updatedUrl.getShortUrl(),
-            updatedUrl.getCreatedAt(),
-            updatedUrl.getUpdatedAt(),
-            updatedUrl.getExpirationDate(),
-            updatedUrl.getAccessCount()
-        );
+                updatedUrl.getId(),
+                updatedUrl.getOriginalUrl(),
+                updatedUrl.getShortUrl(),
+                updatedUrl.getCreatedAt(),
+                updatedUrl.getUpdatedAt(),
+                updatedUrl.getExpirationDate(),
+                updatedUrl.getAccessCount());
     }
 
     public UrlResponse updateOriginalUrl(String shortUrl, UrlRequest urlRequest) {
-        Url url = urlRepository.findByShortUrl(shortUrl).orElseThrow(() -> new ResourceNotFoundException("URL not found: " + shortUrl));
+        Url url = urlRepository.findByShortUrlAndDeletedFalse(shortUrl)
+                .orElseThrow(() -> new RuntimeException("URL not found: " + shortUrl));
 
         url.setAccessCount(0);
-        url.setUpdatedAt(Instant.now());
-        url.setOriginalUrl(urlRequest.getOriginalUrl());
 
         Url updatedUrl = urlRepository.save(url);
 
         return new UrlResponse(
-            updatedUrl.getId(),
-            updatedUrl.getOriginalUrl(),
-            updatedUrl.getShortUrl(),
-            updatedUrl.getCreatedAt(),
-            updatedUrl.getUpdatedAt(),
-            updatedUrl.getExpirationDate(),
-            updatedUrl.getAccessCount()
-        );
+                updatedUrl.getId(),
+                updatedUrl.getOriginalUrl(),
+                updatedUrl.getShortUrl(),
+                updatedUrl.getCreatedAt(),
+                updatedUrl.getUpdatedAt(),
+                updatedUrl.getExpirationDate(),
+                updatedUrl.getAccessCount());
     }
 
-    public UrlResponse deleteUrl(String shortUrl) {
+    public void deleteUrl(String shortUrl) {
+        Url url = urlRepository.findByShortUrlAndDeletedFalse(shortUrl)
+                .orElseThrow(() -> new RuntimeException("URL not found: " + shortUrl));
 
+        url.setDeleted(false);
+        urlRepository.save(url);
     }
 
     public UrlResponse getUrlStats(String shortUrl) {
+        Url url = urlRepository.findByShortUrlAndDeletedFalse(shortUrl)
+                .orElseThrow(() -> new RuntimeException("URL not found: " + shortUrl));
 
+        return new UrlResponse(
+                url.getId(),
+                url.getOriginalUrl(),
+                url.getShortUrl(),
+                url.getCreatedAt(),
+                url.getUpdatedAt(),
+                url.getExpirationDate(),
+                url.getAccessCount());
     }
 
     private String generateShortCode() {
-        return java.util.UUID.randomUUID().toString().substring(0, 6);
+        return java.util.UUID.randomUUID().toString().substring(0, 8);
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,11 @@ spring.application.name=urlshortener
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
+
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
+
+management.endpoints.web.exposure.include=health, env, metrics, loggers
+
+urlentity.lifetime.days=5


### PR DESCRIPTION
Changes:

1. Dockerfile: Add user and groupuser
2. Jpa Auditing: Enabled JPA auditing to automatically populate createdAt and updatedAt fields in the Url entity using @CreatedDate and @LastModifiedDate.
3. Quartz: Configured Quartz to schedule a job that permanently deletes entities marked as deleted after a specified period. Added a property entity.lifetime.days in application.properties to define the entity lifetime.
4. Actuator: Add acturator for health and metrics
5. Controller: Add update and stats end points